### PR TITLE
Enabling direct reporting on HAWQ's website

### DIFF
--- a/index.html
+++ b/index.html
@@ -29,6 +29,8 @@
 
 </script>
 
+<script type="text/javascript" src="https://issues.apache.org/jira/s/bfe7c1e06d911e53fc96873d31176352-T/en_UK-ugtin9/6332/81/1.4.15/_/download/batch/com.atlassian.jira.collector.plugin.jira-issue-collector-plugin:issuecollector/com.atlassian.jira.collector.plugin.jira-issue-collector-plugin:issuecollector.js?locale=en-UK&collectorId=1fdc2dde"></script>
+
 </head>
 
 <body>


### PR DESCRIPTION
This enables the vertical widget on the right hand side of the website similar to what's available on CouchDB's website http://couchdb.apache.org/
