### PR TITLE
Updating doc links to point to hdb.docs.pivotal.io

### DIFF
--- a/index.html
+++ b/index.html
@@ -46,7 +46,7 @@
 
       <div class="menu">
         <a href="#about">About</a>
-        <a href="http://hawq.docs.pivotal.io/index.html">Docs</a>
+        <a href="http://hdb.docs.pivotal.io/index.html">Docs</a>
         <a href="#contribute">Contribute</a>
         <a href="#mailing-lists">Mailing Lists</a>
         <!-- <a href="#download">Download</a> -->
@@ -232,7 +232,7 @@
             </p>
             <ul>
               <li>&mdash; <a href="https://cwiki.apache.org/confluence/display/HAWQ">HAWQ Wiki</a></li>
-              <li>&mdash; <a href="http://hawq.docs.pivotal.io/index.html">HAWQ Docs</a></li>
+              <li>&mdash; <a href="http://hdb.docs.pivotal.io/index.html">HAWQ Docs</a></li>
             </ul>
           </div>
         </div>


### PR DESCRIPTION
The current link to hawq.docs.pivotal.io describes the HAWQ 1.3 (pre Apache HAWQ), which differs significantly from the current code. hdb.docs.pivotal.io is a better match until we open the docs source directly on git.apache.org.
