### PR TITLE
Update copyright section

### DIFF
--- a/index.html
+++ b/index.html
@@ -415,7 +415,7 @@
     <br/>
     <br/>
     <p>
-      Copyright &copy; 2015 <a href='http://www.apache.org/'>The Apache Software Foundation</a>
+      Copyright &copy; 2016 <a href='http://www.apache.org/'>The Apache Software Foundation</a> — Licensed under the <a href="http://www.apache.org/licenses/LICENSE-2.0">Apache License 2.0</a>
       <br>
       Apache, Apache HAWQ (incubating), the Apache feather and the HAWQ logo are trademarks of The Apache Software Foundation
     </p>


### PR DESCRIPTION
Updated copyright year and appended some text regarding the license, to match the format found in other ASF projects' sites, e.g. CouchDB:
<img width="698" alt="screen shot 2016-05-25 at 22 57 33" src="https://cloud.githubusercontent.com/assets/4765455/15562310/2adf76f8-22cc-11e6-820f-1fd55c70a1be.png">
