### PR TITLE
HAWQ-1638. Correct typo and use full name for ASF products 

### DIFF
--- a/index.html
+++ b/index.html
@@ -99,7 +99,7 @@
 
     <h2>Apache HAWQ&reg (incubating) is Apache Hadoop Native SQL. <br />Advanced Analytics MPP Database for Enterprises.</h2>
 
-    <p>In a class by itself, only Apache HAWQ&reg (incubating) combines exceptional MPP-based analytics performance, robust ANSI SQL compliance, Hadoop ecosystem integration and manageability, and flexible data-store format support. All natively in Hadoop. No connectors required.</p>
+    <p>In a class by itself, only Apache HAWQ&reg (incubating) combines exceptional MPP-based analytics performance, robust ANSI SQL compliance, Hadoop ecosystem integration and manageability, and flexible data-store format support. All natively in Apache Hadoop. No connectors required.</p>
 
     <p>Built from a decade’s worth of massively parallel processing (MPP) expertise developed through the creation of the Pivotal Greenplum® enterprise database and open source PostgreSQL, HAWQ&reg enables to you to swiftly and interactively query Hadoop data, natively via HDFS.</p>
 
@@ -110,15 +110,15 @@
       <tr>
         <td valign='top'>
           <p><strong>Exceptional <br/>performance</strong></p>
-          <p>HAWQ&reg’s parallel processing architecture delivers high performance throughput and low latency - potentially near real time - query responses that can scale to petabyte-sized datasets. Operate natively in Hadoop.</p>
+          <p>HAWQ&reg’s parallel processing architecture delivers high performance throughput and low latency - potentially near real time - query responses that can scale to petabyte-sized datasets. Operate natively in Apache Hadoop.</p>
         </td>
         <td valign='top'>
           <p><strong>Robust ANSI SQL compliance</strong></p>
           <p>Leverage familiar skills. Achieve higher levels of compatibility for SQL-based applications and BI/data visualization tools. Execute complex queries and joins, including roll-ups and nested queries.</p>
         </td>
         <td valign='top'>
-          <p><strong>Hadoop ecosystem manageability and integration</strong></p>
-          <p>Integrate and manage with YARN. Provision with Ambari. Interface with HCatalog. HAWQ&reg supports Parquet, AVRO, HBase, and others. Easily scale nodes up or down to meet performance or capacity requirements.</p>
+          <p><strong>Apache Hadoop ecosystem manageability and integration</strong></p>
+          <p>Integrate and manage with Apache YARN. Provision with Ambari. Interface with HCatalog. HAWQ&reg supports Parquet, AVRO, HBase, and others. Easily scale nodes up or down to meet performance or capacity requirements.</p>
         </td>
       </tr>
     </table>
@@ -126,7 +126,7 @@
     <br/>
     <br/>
 
-    <p>Plus, HAWQ&reg works <a href="http://madlib.apache.org">Apache MADlib)</a> machine learning libraries to execute advanced analytics for data-driven digital transformation, modern application development, data science purposes, and more.</p>
+    <p>Plus, HAWQ&reg works with <a href="http://madlib.apache.org">Apache MADlib</a> machine learning libraries to execute advanced analytics for data-driven digital transformation, modern application development, data science purposes, and more.</p>
 
   </div>
 
@@ -138,7 +138,7 @@
     <div class="wrap">
       <h2 class="icon icon-contribute">Contribute to Advanced Enterprise Technology!</h2>
 
-      <p>HAWQ&reg is breaking new ground for advanced analytics and machine learning in Hadoop. All contributors welcome! Get involved with the next wave in Hadoop analytic database technology. HAWQ&reg is fully open source with Apache. Everything from this community, website, and the code itself has been developed by a community of people who want to support and propel HAWQ&reg technology.</p>
+      <p>HAWQ&reg is breaking new ground for advanced analytics and machine learning in Apache Hadoop. All contributors welcome! Get involved with the next wave in Hadoop analytic database technology. HAWQ&reg is fully open source with Apache. Everything from this community, website, and the code itself has been developed by a community of people who want to support and propel HAWQ&reg technology.</p>
 
       <p>We especially welcome additions and corrections to the documentation, wiki, and website to improve user experiences.  Bug reports, and fixes and additions to the HAWQ&reg code are welcome. Helping users learn best practices also earns good karma in our community.</p>
 


### PR DESCRIPTION
Correct typo for madlib and use full name for ASF products with the first/main references.