### PR TITLE
HAWQ-1638. Add how to verify downloaded files section, removed md5 keys.

### DIFF
--- a/index.html
+++ b/index.html
@@ -439,7 +439,7 @@
           <div class="download-list-container"><h2 id="how-to-verify"><a href="http://www.apache.org/info/verification.html">How to verify downloaded files?</a></h2>
               <p>
                   <strong>Note</strong>: When downloading from a mirror, please be sure to verify that checksums and signatures are correct. To do so, use the checksum and signature files from the main Apache site at 
-                  <a href="https://www.apache.org/dist/incubator/hawq/">https://www.apache.org/dist/incubator/hawq/</a>. Find here the KEYS file, which contains all OpenPGP keys we use to sign releases here: 
+                  <a href="https://www.apache.org/dist/incubator/hawq/">https://www.apache.org/dist/incubator/hawq/</a>. Check here to get all the verification required files including OpenPGP keys that we used to sign releases: 
                   <a href="https://www.apache.org/dist/incubator/hawq/KEYS">KEYS</a>
               </p>
               <p>

--- a/index.html
+++ b/index.html
@@ -357,8 +357,7 @@
             <span class="info">
               Version 2.2.0.0 |
               <a href="https://archive.apache.org/dist/incubator/hawq/2.2.0.0-incubating/apache-hawq-rpm-2.2.0.0-incubating.tar.gz.asc">PGP</a> |
-              <a href="https://archive.apache.org/dist/incubator/hawq/2.2.0.0-incubating/apache-hawq-rpm-2.2.0.0-incubating.tar.gz.sha256">SHA-256</a> |
-              <a href="https://archive.apache.org/dist/incubator/hawq/2.2.0.0-incubating/apache-hawq-rpm-2.2.0.0-incubating.tar.gz.md5">MD5</a>
+              <a href="https://archive.apache.org/dist/incubator/hawq/2.2.0.0-incubating/apache-hawq-rpm-2.2.0.0-incubating.tar.gz.sha256">SHA-256</a>
             </span>
           </li>
           <li>
@@ -366,8 +365,7 @@
             <span class="info">
               Version 2.2.0.0 |
               <a href="https://archive.apache.org/dist/incubator/hawq/2.2.0.0-incubating/apache-hawq-src-2.2.0.0-incubating.tar.gz.asc">PGP</a> |
-              <a href="https://archive.apache.org/dist/incubator/hawq/2.2.0.0-incubating/apache-hawq-src-2.2.0.0-incubating.tar.gz.sha256">SHA-256</a> |
-              <a href="https://archive.apache.org/dist/incubator/hawq/2.2.0.0-incubating/apache-hawq-src-2.2.0.0-incubating.tar.gz.md5">MD5</a>
+              <a href="https://archive.apache.org/dist/incubator/hawq/2.2.0.0-incubating/apache-hawq-src-2.2.0.0-incubating.tar.gz.sha256">SHA-256</a>
             </span>
           </li>
         </ul>
@@ -396,8 +394,7 @@
             <span class="info">
               Version 2.1.0.0 |
               <a href="https://archive.apache.org/dist/incubator/hawq/2.1.0.0-incubating/apache-hawq-src-2.1.0.0-incubating.tar.gz.asc">PGP</a> |
-              <a href="https://archive.apache.org/dist/incubator/hawq/2.1.0.0-incubating/apache-hawq-src-2.1.0.0-incubating.tar.gz.sha256">SHA-256</a> |
-              <a href="https://archive.apache.org/dist/incubator/hawq/2.1.0.0-incubating/apache-hawq-src-2.1.0.0-incubating.tar.gz.md5">MD5</a>
+              <a href="https://archive.apache.org/dist/incubator/hawq/2.1.0.0-incubating/apache-hawq-src-2.1.0.0-incubating.tar.gz.sha256">SHA-256</a>
             </span>
           </li>
         </ul>
@@ -427,7 +424,6 @@
               Version 2.0.0.0 |
               <a href="https://archive.apache.org/dist/incubator/hawq/2.0.0.0-incubating/apache-hawq-src-2.0.0.0-incubating.tar.gz.asc">PGP</a> |
               <a href="https://archive.apache.org/dist/incubator/hawq/2.0.0.0-incubating/apache-hawq-src-2.0.0.0-incubating.tar.gz.sha1">SHA-1</a> |
-              <a href="https://archive.apache.org/dist/incubator/hawq/2.0.0.0-incubating/apache-hawq-src-2.0.0.0-incubating.tar.gz.md5">MD5</a>
             </span>
           </li>
         </ul>
@@ -438,6 +434,46 @@
 
   </div>
 
+  <div class="wrap">
+      <div class="corner"></div>
+          <div class="download-list-container"><h2 id="how-to-verify"><a href="http://www.apache.org/info/verification.html">How to verify downloaded files?</a></h2>
+              <p>
+                  <strong>Note</strong>: When downloading from a mirror, please be sure to verify that checksums and signatures are correct. To do so, use the checksum and signature files from the main Apache site at 
+                  <a href="https://www.apache.org/dist/incubator/hawq/">https://www.apache.org/dist/incubator/hawq/</a>. Find here the KEYS file, which contains all OpenPGP keys we use to sign releases here: 
+                  <a href="https://www.apache.org/dist/incubator/hawq/KEYS">KEYS</a>
+              </p>
+              <p>
+                  The PGP signatures can be verified using PGP or GPG. First download the <a href="https://www.apache.org/dist/incubator/hawq/KEYS">KEYS</a> 
+                  as well as the asc signature file for the particular distribution. Then verify the signatures using:
+              </p>
+              <p>
+                  % pgpk -a KEYS
+                  <br><br>
+                  % pgpv ${filename}.tar.gz.asc
+                  <br><br>
+                  or
+                  <br><br>
+                  % pgp -ka KEYS
+                  <br><br>
+                  % pgp ${filename}.tar.gz.asc
+                  <br><br>
+                  or
+                  <br><br>
+                  % gpg --import KEYS
+                  <br><br>
+                  % gpg --verify ${filename}.tar.gz.asc
+                  <br><br>
+              </p>
+              <p>
+                  Alternatively, you can verify the SHA signature on the files.<br>
+                  For example, to check a SHA256 sum of a file:<br>
+                  On Linux:<br>
+                  % sha256sum filename.sha<br>
+                  On Mac:<br>
+                  % shasum -a 256 filename.sha
+              </p>
+      </div>
+  </div>
 
   <a class="scroll-point" id="more"></a>
 


### PR DESCRIPTION
Added a section about how to verify downloaded files.

Removed MD5 references.